### PR TITLE
Use Req with http_errors: :raise

### DIFF
--- a/lib/maplibre.ex
+++ b/lib/maplibre.ex
@@ -588,7 +588,7 @@ defmodule MapLibre do
     Enum.join([String.downcase(part, :ascii) | Enum.map(parts, &String.capitalize(&1, :ascii))])
   end
 
-  defp to_style("http" <> _rest = style), do: Req.get!(style).body
+  defp to_style("http" <> _rest = style), do: Req.get!(style, http_errors: :raise).body
   defp to_style(%{}), do: %{"version" => 8}
   defp to_style(style) when is_map(style), do: style
   defp to_style(style), do: Jason.decode!(style)


### PR DESCRIPTION
Here is the option in action:

    iex> Req.get!("https://httpbin.org/status/404").body
    ""
    iex> Req.get!("https://httpbin.org/status/404", http_errors: :raise).body
    ** (RuntimeError) The requested URL returned error: 404
    Response body: ""
        (req 0.3.0) lib/req/steps.ex:1060: Req.Steps.handle_http_errors/1
        (req 0.3.0) lib/req/request.ex:664: anonymous fn/2 in Req.Request.run_response/2
        (elixir 1.14.0-dev) lib/enum.ex:4754: Enumerable.List.reduce/3
        (elixir 1.14.0-dev) lib/enum.ex:2508: Enum.reduce_while/3
        (req 0.3.0) lib/req/request.ex:663: Req.Request.run_response/2
        (req 0.3.0) lib/req.ex:639: Req.request!/1
        iex:5: (file)
